### PR TITLE
Workaround install crash on Android 5 and below

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# The aapt2 tool creates an APK which fails to install on Android 5 and below if it contains
+# a bug. Build tools 27.0.1 has a mitigation. Avoiding aapt2 also avoids hitting the bug.
+# See: https://issuetracker.google.com/issues/64434571
+android.enableAapt2=false


### PR DESCRIPTION
The aapt2 tool, new to Android Studio 3, creates an APK which fails
to install on Android 5 and below if it contains the following bug:

  https://issuetracker.google.com/issues/64434571

Build tools 27.0.1 has a mitigation. Avoiding aapt2 also avoids hitting
the bug.